### PR TITLE
Rename Kapitan helm_params release_name to name

### DIFF
--- a/class/prometheus-pushgateway.yml
+++ b/class/prometheus-pushgateway.yml
@@ -21,6 +21,6 @@ parameters:
         input_type: helm
         output_path: prometheus-pushgateway/01_helmchart
         helm_params:
-          release_name: platform
+          name: platform
           namespace: ${prometheus_pushgateway:namespace}
         helm_values: ${prometheus_pushgateway:helm_values}


### PR DESCRIPTION
Kapitan has depricated the use of release_name.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
